### PR TITLE
Fixed octree node inheritance bug

### DIFF
--- a/src/Core/Indexes/Octree.cs
+++ b/src/Core/Indexes/Octree.cs
@@ -70,8 +70,8 @@ namespace AEGIS.Indexes
         /// </summary>
         /// <param name="envelope">The maximum indexed region.</param>
         public Octree(Envelope envelope)
-            : base(envelope)
         {
+            this.root = new OctreeNode(envelope);
         }
 
         /// <summary>
@@ -79,8 +79,11 @@ namespace AEGIS.Indexes
         /// </summary>
         /// <param name="geometries">The geometries to add to the tree.</param>
         public Octree(IEnumerable<IBasicGeometry> geometries)
-            : base(geometries)
         {
+            Envelope bound = Envelope.FromEnvelopes(geometries.Select(geometry => geometry.Envelope));
+            this.root = new OctreeNode(bound);
+
+            this.Add(geometries);
         }
     }
 }

--- a/src/Core/Indexes/Octree.cs
+++ b/src/Core/Indexes/Octree.cs
@@ -85,5 +85,25 @@ namespace AEGIS.Indexes
 
             this.Add(geometries);
         }
+
+        /// <summary>
+        /// Clears all geometries from the index.
+        /// </summary>
+        public new void Clear()
+        {
+            this.root = new OctreeNode(this.root.Envelope);
+        }
+
+        /// <summary>
+        /// Creates a new tree based on an unindexed geometry.
+        /// </summary>
+        /// <param name="geometry">The geometry.</param>
+        protected new void CreateNew(IBasicGeometry geometry)
+        {
+            IEnumerable<IBasicGeometry> allGeometries = this.Search(this.root.Envelope);
+            this.root = new OctreeNode(Envelope.FromEnvelopes(this.root.Envelope, geometry.Envelope));
+            this.Add(geometry);
+            this.Add(allGeometries);
+        }
     }
 }

--- a/src/Core/Indexes/Octree.cs
+++ b/src/Core/Indexes/Octree.cs
@@ -89,7 +89,7 @@ namespace AEGIS.Indexes
         /// <summary>
         /// Clears all geometries from the index.
         /// </summary>
-        public new void Clear()
+        public override void Clear()
         {
             this.root = new OctreeNode(this.root.Envelope);
         }
@@ -98,7 +98,7 @@ namespace AEGIS.Indexes
         /// Creates a new tree based on an unindexed geometry.
         /// </summary>
         /// <param name="geometry">The geometry.</param>
-        protected new void CreateNew(IBasicGeometry geometry)
+        protected override void CreateNew(IBasicGeometry geometry)
         {
             IEnumerable<IBasicGeometry> allGeometries = this.Search(this.root.Envelope);
             this.root = new OctreeNode(Envelope.FromEnvelopes(this.root.Envelope, geometry.Envelope));

--- a/src/Core/Indexes/QuadTree.cs
+++ b/src/Core/Indexes/QuadTree.cs
@@ -211,14 +211,21 @@ namespace AEGIS.Indexes
             {
                 List<IBasicGeometry> markedForRemove = new List<IBasicGeometry>();
 
+                bool found;
                 foreach (IBasicGeometry geometry in this.contents)
                 {
+                    found = false;
                     foreach (QuadTreeNode child in this.children)
                     {
-                        if (child.Envelope.Contains(geometry.Envelope))
+                        if (found)
+                        {
+                            break;
+                        }
+                        else if (child.Envelope.Contains(geometry.Envelope))
                         {
                             child.Add(geometry);
                             markedForRemove.Add(geometry);
+                            found = true;
                         }
                     }
                 }
@@ -281,6 +288,7 @@ namespace AEGIS.Indexes
         /// <summary>
         /// Initializes a new instance of the <see cref="QuadTree" /> class.
         /// </summary>
+        /// <remarks>This constructor does not properly initializes the object (root will be null), and the constructor of the descendant class calling this must initialize it.</remarks>
         protected QuadTree()
         {
         }
@@ -411,7 +419,7 @@ namespace AEGIS.Indexes
         /// <summary>
         /// Clears all geometries from the index.
         /// </summary>
-        public void Clear()
+        public virtual void Clear()
         {
             this.root = new QuadTreeNode(this.root.Envelope);
         }
@@ -420,7 +428,7 @@ namespace AEGIS.Indexes
         /// Creates a new tree based on an unindexed geometry.
         /// </summary>
         /// <param name="geometry">The geometry.</param>
-        protected void CreateNew(IBasicGeometry geometry)
+        protected virtual void CreateNew(IBasicGeometry geometry)
         {
             IEnumerable<IBasicGeometry> allGeometries = this.Search(this.root.Envelope);
             this.root = new QuadTreeNode(Envelope.FromEnvelopes(this.root.Envelope, geometry.Envelope));

--- a/src/Core/Indexes/QuadTree.cs
+++ b/src/Core/Indexes/QuadTree.cs
@@ -231,7 +231,7 @@ namespace AEGIS.Indexes
         /// <summary>
         /// The root of the tree.
         /// </summary>
-        private QuadTreeNode root;
+        protected QuadTreeNode root;
 
         /// <summary>
         /// Gets a value indicating whether the index is read-only.
@@ -276,6 +276,13 @@ namespace AEGIS.Indexes
             this.root = new QuadTreeNode(bound);
 
             this.Add(geometries);
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="QuadTree" /> class.
+        /// </summary>
+        protected QuadTree()
+        {
         }
 
         /// <summary>

--- a/src/Core/Indexes/QuadTree.cs
+++ b/src/Core/Indexes/QuadTree.cs
@@ -420,7 +420,7 @@ namespace AEGIS.Indexes
         /// Creates a new tree based on an unindexed geometry.
         /// </summary>
         /// <param name="geometry">The geometry.</param>
-        private void CreateNew(IBasicGeometry geometry)
+        protected void CreateNew(IBasicGeometry geometry)
         {
             IEnumerable<IBasicGeometry> allGeometries = this.Search(this.root.Envelope);
             this.root = new QuadTreeNode(Envelope.FromEnvelopes(this.root.Envelope, geometry.Envelope));


### PR DESCRIPTION
The Octree had a bug, where the root node was initialized as a QuadTreeNode instead of an OctreeNode.